### PR TITLE
Add Every Other Day Option

### DIFF
--- a/app/models/concerns/recurring_events.rb
+++ b/app/models/concerns/recurring_events.rb
@@ -74,6 +74,8 @@ module RecurringEvents
         n_time.months
       when 'every 2 weeks'
         n_time * 2.weeks
+      when 'every other day'
+        n_time * 2.days
       else
         n_time.days
       end

--- a/app/models/concerns/recurring_events.rb
+++ b/app/models/concerns/recurring_events.rb
@@ -67,18 +67,13 @@ module RecurringEvents
     end
 
     def recurring_schedule(event, n_time)
-      case event.recurring_schedule
-      when 'weekly'
-        n_time.weeks
-      when 'monthly'
-        n_time.months
-      when 'every 2 weeks'
-        n_time * 2.weeks
-      when 'every other day'
-        n_time * 2.days
-      else
-        n_time.days
-      end
+      schedule = {
+        'weekly' => n_time.weeks,
+        'monthly' => n_time.months,
+        'every 2 weeks' => n_time * 2.weeks,
+        'every other day' => n_time * 2.days
+      }
+      schedule.fetch(event.recurring_schedule, n_time.days)
     end
   end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -27,7 +27,7 @@
       </div>
 
       <div class="collapse" id="collapseRecurring">
-        <%= f.input :recurring_schedule, as: :radio_buttons, collection: ['daily', 'weekly', 'monthly', 'every 2 weeks'] %>
+        <%= f.input :recurring_schedule, as: :radio_buttons, collection: ['daily', 'weekly', 'monthly', 'every 2 weeks', 'every other day'] %>
 
         <%= f.input :recurring_times, as: :integer, html5: true %>
       </div>

--- a/test/integration/recurring_test.rb
+++ b/test/integration/recurring_test.rb
@@ -84,6 +84,20 @@ class RecurringTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'should create every other day events' do
+    visit('/')
+    assert_difference 'Event.count', 3 do
+      create_events('09:00AM', '02:00PM', 'Green', 2, 'every other day')
+      assert_text('test title', count: 3)
+    end
+
+    if Time.zone.now.sunday?
+      assert_equal (Time.zone.now.beginning_of_day - 4.days + 14.hours), Event.order(end: :desc).first.end
+    else
+      assert_equal (Time.zone.now.beginning_of_week + 4.days + 14.hours), Event.order(end: :desc).first.end
+    end
+  end
+
   test 'should update multiple events' do
     visit('/')
     create_events('09:00AM', '02:00PM', 'Green', 2)


### PR DESCRIPTION
This pull request introduces a new recurring schedule option, "every other day," to the event management system. The changes include updates to the logic for handling recurring schedules, the user interface for selecting schedules, and the test suite to ensure functionality.

### Updates to recurring schedule logic:

* [`app/models/concerns/recurring_events.rb`](diffhunk://#diff-5cd2604b1cd800ad0ac6da34893bb0876741c3d6c887ce13bfdd9abaaee327cbL70-R76): Refactored the `recurring_schedule` method to use a hash for mapping schedule types to their corresponding time intervals. Added support for the new "every other day" schedule.

### User interface enhancements:

* [`app/views/events/_form.html.erb`](diffhunk://#diff-1f1b76789d27852b7ed35b5f4649f39f999abafd7c2fdaf2b72f09c110c69601L30-R30): Updated the recurring schedule radio button options to include "every other day."

### Test suite additions:

* [`test/integration/recurring_test.rb`](diffhunk://#diff-c7f8286fa91fcd485f06b6490e46d31fbb910dca470bb86b5228458fe33c9783R87-R100): Added a new test case to validate the creation of events with the "every other day" schedule, ensuring the correct number of events and their calculated end times.