### PR TITLE
Enable CORS for API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'fullcalendar-rails', '~> 3.9'
 # Use momentjs for the JavaScript date formating
 gem 'momentjs-rails', '~> 2.29'
 
+# Use rack-cors for CORS
+gem 'rack-cors', '~> 3.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -346,6 +349,7 @@ DEPENDENCIES
   momentjs-rails (~> 2.29)
   mysql2 (~> 0.5.6)
   puma (~> 6.5)
+  rack-cors (~> 3.0)
   rails (~> 8.0)
   rubocop-capybara
   rubocop-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,16 @@
+# Be sure to restart your server when you modify this file.
+
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
+
+# Read more: https://github.com/cyu/rack-cors
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '/api/v1/*',
+             headers: :any,
+             methods: %i[get post put patch delete options head]
+  end
+end


### PR DESCRIPTION
This pull request introduces support for Cross-Origin Resource Sharing (CORS) to the application, allowing cross-origin requests to the API endpoints. The changes include adding the `rack-cors` gem and configuring it to permit requests from any origin to the `/api/v1/*` routes.

**CORS support:**

* Added the `rack-cors` gem to the `Gemfile` to enable handling of CORS requests.
* Created a new initializer `config/initializers/cors.rb` to configure CORS, allowing any origin to access `/api/v1/*` routes with any HTTP headers and standard HTTP methods.