### PR TITLE
Add OpenAPI Documentation for API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ gem 'momentjs-rails', '~> 2.29'
 # Use rack-cors for CORS
 gem 'rack-cors', '~> 3.0'
 
+# Use RSwag for API documentation
+gem 'rswag-api', '~> 2.16'
+gem 'rswag-ui', '~> 2.16'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,12 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.4.2)
+    rswag-api (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
+    rswag-ui (2.16.0)
+      actionpack (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
     rubocop (1.80.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -351,6 +357,8 @@ DEPENDENCIES
   puma (~> 6.5)
   rack-cors (~> 3.0)
   rails (~> 8.0)
+  rswag-api (~> 2.16)
+  rswag-ui (~> 2.16)
   rubocop-capybara
   rubocop-rails
   sass-rails (~> 6.0)

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.join('swagger').to_s
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   root 'events#index'
   resources :events
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -246,12 +246,12 @@ components:
             recurring_schedule:
               type: string
               enum:
+                - null
                 - daily
                 - weekly
                 - monthly
                 - every 2 weeks
                 - every other day
-                - null
           required:
             - start
             - end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -201,40 +201,43 @@ components:
     EventInput:
       type: object
       properties:
-        title:
-          type: string
-        start:
-          type: string
-          format: date-time
-        end:
-          type: string
-          format: date-time
-        color:
-          type: string
-          enum:
-            - black
-            - green
-            - red
-            - midnightblue
-            - indigo
-            - darkorange
-            - sienna
-            - teal
-            - null
-        recurring_times:
-          type: integer
-        apply_to_series:
-          type: boolean
-        recurring_schedule:
-          type: string
-          enum: 
-            - daily
-            - weekly
-            - monthly
-            - every 2 weeks
-            - every other day
-            - null
-      required:
-        - title
-        - start
-        - end
+        event:
+          type: object
+          properties:
+            title:
+              type: string
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+            color:
+              type: string
+              enum:
+                - black
+                - green
+                - red
+                - midnightblue
+                - indigo
+                - darkorange
+                - sienna
+                - teal
+                - null
+            recurring_times:
+              type: integer
+            apply_to_series:
+              type: boolean
+            recurring_schedule:
+              type: string
+              enum: 
+                - daily
+                - weekly
+                - monthly
+                - every 2 weeks
+                - every other day
+                - null
+          required:
+            - title
+            - start
+            - end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -185,6 +185,18 @@ components:
         end:
           type: string
           format: date-time
+        color:
+          type: string
+          enum:
+            - null
+            - black
+            - green
+            - red
+            - midnightblue
+            - indigo
+            - darkorange
+            - sienna
+            - teal
         created_at:
           type: string
         updated_at:
@@ -212,6 +224,7 @@ components:
             color:
               type: string
               enum:
+                - null
                 - black
                 - green
                 - red
@@ -220,7 +233,6 @@ components:
                 - darkorange
                 - sienna
                 - teal
-                - null
             recurring_times:
               type: integer
             apply_to_series:
@@ -231,7 +243,7 @@ components:
                 - null
             recurring_schedule:
               type: string
-              enum: 
+              enum:
                 - daily
                 - weekly
                 - monthly
@@ -239,6 +251,5 @@ components:
                 - every other day
                 - null
           required:
-            - title
             - start
             - end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.1
 info:
   title: Home Calendar API
-  version: v1
+  version: 1.0.0
   description: |
     API for managing calendar events, including recurring series.
 servers:
@@ -211,12 +211,29 @@ components:
           format: date-time
         color:
           type: string
+          enum:
+            - black
+            - green
+            - red
+            - midnightblue
+            - indigo
+            - darkorange
+            - sienna
+            - teal
+            - null
         recurring_times:
           type: integer
         apply_to_series:
           type: boolean
         recurring_schedule:
           type: string
+          enum: 
+            - daily
+            - weekly
+            - monthly
+            - every 2 weeks
+            - every other day
+            - null
       required:
         - title
         - start

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -224,7 +224,11 @@ components:
             recurring_times:
               type: integer
             apply_to_series:
-              type: boolean
+              type: string
+              enum:
+                - "0"
+                - "1"
+                - null
             recurring_schedule:
               type: string
               enum: 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -185,17 +185,14 @@ components:
         end:
           type: string
           format: date-time
-        color:
+        created_at:
           type: string
-        recurring_times:
-          type: integer
-        apply_to_series:
-          type: boolean
-        recurring_schedule:
+        updated_at:
+          type: string
+        recurring_uuid:
           type: string
       required:
         - id
-        - title
         - start
         - end
     EventInput:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -162,12 +162,6 @@ paths:
       responses:
         '204':
           description: Event(s) deleted
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Event'
         '404':
           description: Event not found
           content:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,77 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/events":
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create item
+      parameters: []
+      responses:
+        '201':
+          description: created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                item_id:
+                  type: string
+                position:
+                  type: integer
+              required:
+              - item_id
+        required: true
+  "/api/v1/events/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show item
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update item
+      parameters: []
+      responses:
+        '200':
+          description: successful
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                item_id:
+                  type: string
+                position:
+                  type: integer
+              required:
+              - item_id
+        required: true
+    delete:
+      summary: delete item
+      responses:
+        '204':
+          description: no content
+servers:
+- url: "{protocol}://{host}:{port}"
+  variables:
+    protocol:
+      default: http
+    host:
+      default: localhost
+    port:
+      default: '3000'

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -188,7 +188,7 @@ components:
         color:
           type: string
           enum:
-            - null
+            - ""
             - black
             - green
             - red
@@ -205,6 +205,7 @@ components:
           format: date-time
         recurring_uuid:
           type: string
+          nullable: true
       required:
         - id
         - start
@@ -226,7 +227,7 @@ components:
             color:
               type: string
               enum:
-                - null
+                - ""
                 - black
                 - green
                 - red
@@ -239,12 +240,14 @@ components:
               type: integer
             apply_to_series:
               type: string
+              nullable: true
               enum:
                 - "0"
                 - "1"
                 - null
             recurring_schedule:
               type: string
+              nullable: true
               enum:
                 - null
                 - daily

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,71 +1,10 @@
 ---
 openapi: 3.0.1
 info:
-  title: API V1
+  title: Home Calendar API
   version: v1
-paths:
-  "/api/v1/events":
-    get:
-      summary: list items
-      responses:
-        '200':
-          description: successful
-    post:
-      summary: create item
-      parameters: []
-      responses:
-        '201':
-          description: created
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                item_id:
-                  type: string
-                position:
-                  type: integer
-              required:
-              - item_id
-        required: true
-  "/api/v1/events/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show item
-      responses:
-        '200':
-          description: successful
-    patch:
-      summary: update item
-      parameters: []
-      responses:
-        '200':
-          description: successful
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                item_id:
-                  type: string
-                position:
-                  type: integer
-              required:
-              - item_id
-        required: true
-    delete:
-      summary: delete item
-      responses:
-        '204':
-          description: no content
+  description: |
+    API for managing calendar events, including recurring series.
 servers:
 - url: "{protocol}://{host}:{port}"
   variables:
@@ -75,3 +14,216 @@ servers:
       default: localhost
     port:
       default: '3000'
+
+paths:
+  /api/v1/events:
+    get:
+      summary: List events in a date range
+      operationId: listEvents
+      parameters:
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: Start of the date range (inclusive)
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: End of the date range (inclusive)
+      responses:
+        '200':
+          description: A list of events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Missing or invalid parameters
+          content:
+            text/plain:
+              schema:
+                type: string
+    post:
+      summary: Create a new event (or series)
+      operationId: createEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventInput'
+      responses:
+        '201':
+          description: Event(s) created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /api/v1/events/{id}:
+    get:
+      summary: Retrieve a single event
+      operationId: getEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+      responses:
+        '200':
+          description: Event found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+    patch:
+      summary: Update an event (or series)
+      operationId: updateEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventInput'
+      responses:
+        '200':
+          description: Event(s) updated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+    delete:
+      summary: Delete an event (or series)
+      operationId: deleteEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+        - in: query
+          name: apply_to_series
+          required: false
+          schema:
+            type: boolean
+          description: |
+            If true, delete the entire series; otherwise delete only this occurrence.
+      responses:
+        '204':
+          description: Event(s) deleted
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        color:
+          type: string
+        recurring_times:
+          type: integer
+        apply_to_series:
+          type: boolean
+        recurring_schedule:
+          type: string
+      required:
+        - id
+        - title
+        - start
+        - end
+    EventInput:
+      type: object
+      properties:
+        title:
+          type: string
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        color:
+          type: string
+        recurring_times:
+          type: integer
+        apply_to_series:
+          type: boolean
+        recurring_schedule:
+          type: string
+      required:
+        - title
+        - start
+        - end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -199,8 +199,10 @@ components:
             - teal
         created_at:
           type: string
+          format: date-time
         updated_at:
           type: string
+          format: date-time
         recurring_uuid:
           type: string
       required:

--- a/test/integration/recurring_test.rb
+++ b/test/integration/recurring_test.rb
@@ -92,7 +92,7 @@ class RecurringTest < ActionDispatch::IntegrationTest
     end
 
     if Time.zone.now.sunday?
-      assert_equal (Time.zone.now.beginning_of_day - 4.days + 14.hours), Event.order(end: :desc).first.end
+      assert_equal (Time.zone.now.beginning_of_day + 4.days + 14.hours), Event.order(end: :desc).first.end
     else
       assert_equal (Time.zone.now.beginning_of_week + 4.days + 14.hours), Event.order(end: :desc).first.end
     end


### PR DESCRIPTION
This pull request adds support for interactive API documentation using RSwag, enabling both OpenAPI specification generation and a Swagger UI for the Home Calendar API. The changes include new dependencies, configuration files, routing updates, and an initial OpenAPI YAML describing the events API endpoints and schemas.

**API Documentation Integration**

* Added `rswag-api` and `rswag-ui` gems to the `Gemfile` for OpenAPI/Swagger support.
* Created initializer files `config/initializers/rswag_api.rb` and `config/initializers/rswag_ui.rb` to configure RSwag's API and UI engines, including the OpenAPI root and Swagger endpoint. [[1]](diffhunk://#diff-679586a0ce63af305fa716c9287a270b0367260637a4fe9fa370ff88ca5e9e30R1-R13) [[2]](diffhunk://#diff-14ef7af3b0960016b78c768f3efc78a938c2f79b979dc839d0235dd2e2e1c1a9R1-R15)
* Updated `config/routes.rb` to mount the RSwag UI and API engines at `/api-docs`, making the documentation accessible via browser.

**OpenAPI Specification**

* Added a new OpenAPI 3.0 YAML file at `swagger/v1/swagger.yaml` describing the Home Calendar API, including endpoints for listing, creating, retrieving, updating, and deleting events, as well as detailed schemas for request and response payloads.

**Test Correction**

* Fixed a test assertion in `test/integration/recurring_test.rb` to correctly calculate the expected event end date for Sundays.