### PR TITLE
Add llm.txt and llm.md

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,9 @@ GEM
       thor (~> 1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
@@ -366,9 +366,9 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/public/llm.md
+++ b/public/llm.md
@@ -1,0 +1,122 @@
+# Home Calendar API
+
+**Version:** 1.0.0
+
+API for managing calendar events, including recurring series.
+
+**Base URL:** `{protocol}://{host}:{port}` (default: `http://localhost:3000`)
+
+
+## Endpoints
+
+### `GET /api/v1/events` — List events in a date range
+
+**Query Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `start` | yes | string (date-time) | Start of the date range (inclusive) |
+| `end` | yes | string (date-time) | End of the date range (inclusive) |
+
+**Responses:**
+
+- `200` — Array of `Event` objects
+- `400` — Missing or invalid parameters (plain text)
+
+---
+
+### `POST /api/v1/events` — Create a new event (or series)
+
+**Request Body:** `EventInput` (JSON)
+
+**Responses:**
+
+- `201` — Array of created `Event` objects
+- `400` — Array of validation error strings
+
+---
+
+### `GET /api/v1/events/{id}` — Retrieve a single event
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Responses:**
+
+- `200` — `Event` object
+- `404` — Empty object
+
+---
+
+### `PATCH /api/v1/events/{id}` — Update an event (or series)
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Request Body:** `EventInput` (JSON)
+
+**Responses:**
+
+- `200` — Array of updated `Event` objects
+- `400` — Array of validation error strings
+- `404` — Empty object
+
+---
+
+### `DELETE /api/v1/events/{id}` — Delete an event (or series)
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Query Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `apply_to_series` | no | boolean | If true, delete the entire series; otherwise delete only this occurrence |
+
+**Responses:**
+
+- `204` — Event(s) deleted
+- `404` — Empty object
+
+---
+
+## Schemas
+
+### `Event`
+
+| Property | Type | Required | Notes |
+|----------|------|----------|-------|
+| `id` | integer | yes | |
+| `title` | string | no | |
+| `start` | string (date-time) | yes | |
+| `end` | string (date-time) | yes | |
+| `color` | string (enum) | no | `""`, `black`, `green`, `red`, `midnightblue`, `indigo`, `darkorange`, `sienna`, `teal` |
+| `created_at` | string (date-time) | no | |
+| `updated_at` | string (date-time) | no | |
+| `recurring_uuid` | string | no | nullable |
+
+---
+
+### `EventInput`
+
+Wraps event fields under an `event` key.
+
+| Property | Type | Required | Notes |
+|----------|------|----------|-------|
+| `event.title` | string | no | |
+| `event.start` | string (date-time) | yes | |
+| `event.end` | string (date-time) | yes | |
+| `event.color` | string (enum) | no | `""`, `black`, `green`, `red`, `midnightblue`, `indigo`, `darkorange`, `sienna`, `teal` |
+| `event.recurring_times` | integer | no | |
+| `event.apply_to_series` | string (enum) | no | `"0"`, `"1"`, or null |
+| `event.recurring_schedule` | string (enum) | no | `daily`, `weekly`, `monthly`, `every 2 weeks`, `every other day`, or null |

--- a/public/llm.md
+++ b/public/llm.md
@@ -9,7 +9,7 @@ API for managing calendar events, including recurring series.
 
 ## Endpoints
 
-### `GET /api/v1/events` — List events in a date range
+### `GET /api/v1/events` - List events in a date range
 
 **Query Parameters:**
 
@@ -20,23 +20,23 @@ API for managing calendar events, including recurring series.
 
 **Responses:**
 
-- `200` — Array of `Event` objects
-- `400` — Missing or invalid parameters (plain text)
+- `200` - Array of `Event` objects
+- `400` - Missing or invalid parameters (plain text)
 
 ---
 
-### `POST /api/v1/events` — Create a new event (or series)
+### `POST /api/v1/events` - Create a new event (or series)
 
 **Request Body:** `EventInput` (JSON)
 
 **Responses:**
 
-- `201` — Array of created `Event` objects
-- `400` — Array of validation error strings
+- `201` - Array of created `Event` objects
+- `400` - Array of validation error strings
 
 ---
 
-### `GET /api/v1/events/{id}` — Retrieve a single event
+### `GET /api/v1/events/{id}` - Retrieve a single event
 
 **Path Parameters:**
 
@@ -46,12 +46,12 @@ API for managing calendar events, including recurring series.
 
 **Responses:**
 
-- `200` — `Event` object
-- `404` — Empty object
+- `200` - `Event` object
+- `404` - Empty object
 
 ---
 
-### `PATCH /api/v1/events/{id}` — Update an event (or series)
+### `PATCH /api/v1/events/{id}` - Update an event (or series)
 
 **Path Parameters:**
 
@@ -63,13 +63,13 @@ API for managing calendar events, including recurring series.
 
 **Responses:**
 
-- `200` — Array of updated `Event` objects
-- `400` — Array of validation error strings
-- `404` — Empty object
+- `200` - Array of updated `Event` objects
+- `400` - Array of validation error strings
+- `404` - Empty object
 
 ---
 
-### `DELETE /api/v1/events/{id}` — Delete an event (or series)
+### `DELETE /api/v1/events/{id}` - Delete an event (or series)
 
 **Path Parameters:**
 
@@ -85,8 +85,8 @@ API for managing calendar events, including recurring series.
 
 **Responses:**
 
-- `204` — Event(s) deleted
-- `404` — Empty object
+- `204` - Event(s) deleted
+- `404` - Empty object
 
 ---
 

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -1,0 +1,7 @@
+# Home Calendar API
+
+> Backend API for managing calendar events, including recurring series. Built with Ruby on Rails. The frontend is at https://github.com/JavaKoala/home-calendar-react.
+
+## API Documentation
+
+- llm.md

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -1,7 +1,122 @@
 # Home Calendar API
 
-> Backend API for managing calendar events, including recurring series. Built with Ruby on Rails. The frontend is at https://github.com/JavaKoala/home-calendar-react.
+**Version:** 1.0.0
 
-## API Documentation
+API for managing calendar events, including recurring series.
 
-- llm.md
+**Base URL:** `{protocol}://{host}:{port}` (default: `http://localhost:3000`)
+
+
+## Endpoints
+
+### `GET /api/v1/events` - List events in a date range
+
+**Query Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `start` | yes | string (date-time) | Start of the date range (inclusive) |
+| `end` | yes | string (date-time) | End of the date range (inclusive) |
+
+**Responses:**
+
+- `200` - Array of `Event` objects
+- `400` - Missing or invalid parameters (plain text)
+
+---
+
+### `POST /api/v1/events` - Create a new event (or series)
+
+**Request Body:** `EventInput` (JSON)
+
+**Responses:**
+
+- `201` - Array of created `Event` objects
+- `400` - Array of validation error strings
+
+---
+
+### `GET /api/v1/events/{id}` - Retrieve a single event
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Responses:**
+
+- `200` - `Event` object
+- `404` - Empty object
+
+---
+
+### `PATCH /api/v1/events/{id}` - Update an event (or series)
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Request Body:** `EventInput` (JSON)
+
+**Responses:**
+
+- `200` - Array of updated `Event` objects
+- `400` - Array of validation error strings
+- `404` - Empty object
+
+---
+
+### `DELETE /api/v1/events/{id}` - Delete an event (or series)
+
+**Path Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `id` | yes | integer | Event ID |
+
+**Query Parameters:**
+
+| Name | Required | Type | Description |
+|------|----------|------|-------------|
+| `apply_to_series` | no | boolean | If true, delete the entire series; otherwise delete only this occurrence |
+
+**Responses:**
+
+- `204` - Event(s) deleted
+- `404` - Empty object
+
+---
+
+## Schemas
+
+### `Event`
+
+| Property | Type | Required | Notes |
+|----------|------|----------|-------|
+| `id` | integer | yes | |
+| `title` | string | no | |
+| `start` | string (date-time) | yes | |
+| `end` | string (date-time) | yes | |
+| `color` | string (enum) | no | `""`, `black`, `green`, `red`, `midnightblue`, `indigo`, `darkorange`, `sienna`, `teal` |
+| `created_at` | string (date-time) | no | |
+| `updated_at` | string (date-time) | no | |
+| `recurring_uuid` | string | no | nullable |
+
+---
+
+### `EventInput`
+
+Wraps event fields under an `event` key.
+
+| Property | Type | Required | Notes |
+|----------|------|----------|-------|
+| `event.title` | string | no | |
+| `event.start` | string (date-time) | yes | |
+| `event.end` | string (date-time) | yes | |
+| `event.color` | string (enum) | no | `""`, `black`, `green`, `red`, `midnightblue`, `indigo`, `darkorange`, `sienna`, `teal` |
+| `event.recurring_times` | integer | no | |
+| `event.apply_to_series` | string (enum) | no | `"0"`, `"1"`, or null |
+| `event.recurring_schedule` | string (enum) | no | `daily`, `weekly`, `monthly`, `every 2 weeks`, `every other day`, or null |


### PR DESCRIPTION
This pull request adds comprehensive API documentation for the Home Calendar API, covering available endpoints, request and response formats, and data schemas. The documentation is provided in both Markdown (`llm.md`) and plain text (`llm.txt`) formats.

**API Documentation Additions:**

* Added a full overview of the Home Calendar API, including version, base URL, and purpose.
* Documented all main endpoints for managing calendar events: listing, creating, retrieving, updating, and deleting events (including recurring series), with details on parameters and responses.
* Defined the data schemas for `Event` and `EventInput`, specifying required fields, types, and enumerated values for properties like `color` and recurrence options.