### PR TITLE
Add ICalendar Export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'openssl'
 # Include ostruct
 gem 'ostruct'
 
+# Use iCalendar for ical export
+gem 'icalendar', '~> 2.12'
+
 group :development, :test do
   gem 'bundler-audit', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,12 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    icalendar (2.12.3)
+      base64
+      ice_cube (~> 0.16)
+      logger
+      ostruct
+    ice_cube (0.17.0)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -327,6 +333,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   byebug
+  icalendar (~> 2.12)
   jbuilder (~> 2.13)
   listen (~> 3.9)
   mysql2 (~> 0.5.6)
@@ -384,6 +391,8 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  icalendar (2.12.3) sha256=37dea76c36f5b21dd745bcd3cb53e7bacfbb4ad0a8d9c2a1c0aa9d39af83c850
+  ice_cube (0.17.0) sha256=32deb45dda4b4acc53505c2f581f6d32b5afc04d29b9004769944a0df5a5fcbe
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.4)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -130,7 +130,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -217,8 +217,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -313,7 +313,7 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -396,12 +396,12 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
-  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
@@ -437,7 +437,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
@@ -474,7 +474,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 

--- a/app/controllers/api/v1/icalendar_controller.rb
+++ b/app/controllers/api/v1/icalendar_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class IcalendarController < ApplicationController
+      def index
+        if params[:start].present? && params[:end].present?
+          service = ICalService.new(event_start: params[:start], event_end: params[:end])
+
+          send_data service.icalendar.to_ical,
+                    filename: 'test.ics',
+                    type: 'text/calendar',
+                    disposition: 'attachment'
+        else
+          render status: :bad_request, plain: 'start and end parameters are required'
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/icalendar_controller.rb
+++ b/app/controllers/api/v1/icalendar_controller.rb
@@ -6,7 +6,7 @@ module Api
           service = ICalService.new(event_start: params[:start], event_end: params[:end])
 
           send_data service.icalendar.to_ical,
-                    filename: 'test.ics',
+                    filename: 'home_calendar.ics',
                     type: 'text/calendar',
                     disposition: 'attachment'
         else

--- a/app/controllers/api/v1/icalendar_controller.rb
+++ b/app/controllers/api/v1/icalendar_controller.rb
@@ -5,7 +5,7 @@ module Api
         if params[:start].present? && params[:end].present?
           service = ICalService.new(event_start: params[:start], event_end: params[:end])
 
-          send_data service.icalendar.to_ical,
+          send_data service.to_ical,
                     filename: 'home_calendar.ics',
                     type: 'text/calendar',
                     disposition: 'attachment'

--- a/app/services/i_cal_service.rb
+++ b/app/services/i_cal_service.rb
@@ -20,6 +20,7 @@ class ICalService
   end
 
   def find_events
-    Event.where(start: @event_start..@event_end).or(Event.where(end: @event_start..@event_end))
+    t = Event.arel_table
+    Event.where(t[:start].lteq(@event_end).and(t[:end].gteq(@event_start)))
   end
 end

--- a/app/services/i_cal_service.rb
+++ b/app/services/i_cal_service.rb
@@ -1,8 +1,25 @@
 class ICalService
-  def initialize(cal_start:, cal_end:)
+  def initialize(event_start:, event_end:)
+    @event_start = event_start
+    @event_end = event_end
   end
 
+  delegate :to_ical, to: :icalendar
+
   def icalendar
-    Icalendar::Calendar.new
+    calendar = Icalendar::Calendar.new
+    find_events.each do |event|
+      calendar.event do |e|
+        e.dtstart = Icalendar::Values::Date.new(event.start)
+        e.dtend = Icalendar::Values::Date.new(event.end)
+        e.summary = event.title
+      end
+    end
+
+    calendar
+  end
+
+  def find_events
+    Event.where(start: @event_start..@event_end).or(Event.where(end: @event_start..@event_end))
   end
 end

--- a/app/services/i_cal_service.rb
+++ b/app/services/i_cal_service.rb
@@ -1,0 +1,8 @@
+class ICalService
+  def initialize(cal_start:, cal_end:)
+  end
+
+  def icalendar
+    Icalendar::Calendar.new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :events
+      resources :icalendar, only: :index
     end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -203,7 +203,7 @@ paths:
                 type: string
                 example: attachment; filename="home_calendar.ics"
         '400':
-          description: Missing or invalid parameters
+          description: Missing parameters
           content:
             text/plain:
               schema:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -170,6 +170,44 @@ paths:
                 type: object
                 properties: {}
 
+  /api/v1/icalendar:
+    get:
+      summary: Returns ics file with events in a date range
+      operationId: icsEvents
+      parameters:
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: Start of the date range
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: End of the date range
+      responses:
+        '200':
+          description: Returns the iCalendar file for the event
+          content:
+            text/calendar:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: attachment; filename="home_calendar.ics"
+        '400':
+          description: Missing or invalid parameters
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     Event:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -191,7 +191,7 @@ paths:
           description: End of the date range
       responses:
         '200':
-          description: Returns the iCalendar file for the event
+          description: Returns the iCalendar file for the events
           content:
             text/calendar:
               schema:

--- a/test/controllers/api/v1/icalendar_controller_test.rb
+++ b/test/controllers/api/v1/icalendar_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module Api
+  module V1
+    class IcalendarControllerTest < ActionDispatch::IntegrationTest
+      test 'should get index' do
+        get api_v1_icalendar_index_path, params: { start: Event.last.start, end: Event.last.end }
+
+        assert_response :success
+        assert_equal 'text/calendar', response.media_type
+        assert_match(/attachment; filename="test\.ics"/, response.headers['Content-Disposition'])
+        assert_includes response.body, 'VCALENDAR'
+      end
+
+      test 'should return bad request if start is not present' do
+        get api_v1_icalendar_index_path, params: { end: Event.last.end }
+
+        assert_response :bad_request
+        assert_equal response.body, 'start and end parameters are required'
+      end
+
+      test 'should return bad request if end is not present' do
+        get api_v1_icalendar_index_path, params: { start: Event.last.start }
+
+        assert_response :bad_request
+        assert_equal response.body, 'start and end parameters are required'
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/icalendar_controller_test.rb
+++ b/test/controllers/api/v1/icalendar_controller_test.rb
@@ -16,7 +16,7 @@ module Api
         get api_v1_icalendar_index_path, params: { end: Event.last.end }
 
         assert_response :bad_request
-        assert_equal response.body, 'start and end parameters are required'
+        assert_equal 'start and end parameters are required', response.body
       end
 
       test 'should return bad request if end is not present' do

--- a/test/controllers/api/v1/icalendar_controller_test.rb
+++ b/test/controllers/api/v1/icalendar_controller_test.rb
@@ -8,7 +8,7 @@ module Api
 
         assert_response :success
         assert_equal 'text/calendar', response.media_type
-        assert_match(/attachment; filename="test\.ics"/, response.headers['Content-Disposition'])
+        assert_match(/attachment; filename="home_calendar\.ics"/, response.headers['Content-Disposition'])
         assert_includes response.body, 'VCALENDAR'
       end
 

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -22,8 +22,8 @@ class ICalServiceTest < ActiveSupport::TestCase
 
     service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
 
-    assert_equal service.icalendar.events.first.dtstart, event.start.to_date
-    assert_equal service.icalendar.events.first.dtend, event.end.to_date
-    assert_equal service.icalendar.events.first.summary, event.title
+    assert_equal event.start.to_date, service.icalendar.events.first.dtstart
+    assert_equal event.end.to_date, service.icalendar.events.first.dtend
+    assert_equal event.title, service.icalendar.events.first.summary
   end
 end

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -6,4 +6,23 @@ class ICalServiceTest < ActiveSupport::TestCase
 
     assert_kind_of Icalendar::Calendar, service.icalendar
   end
+
+  test 'returns events in window' do
+    Event.create(start: 1.hour.ago, end: Time.current)
+    Event.create(start: 2.weeks.ago, end: 1.week.ago)
+
+    service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
+
+    assert_equal service.icalendar.events.count, 1
+  end
+
+  test 'returns event parameters' do
+    event = Event.create(start: 1.hour.ago, end: Time.current, title: 'Test title')
+
+    service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
+
+    assert_equal service.icalendar.events.first.dtstart, event.start.to_date
+    assert_equal service.icalendar.events.first.dtend, event.end.to_date
+    assert_equal service.icalendar.events.first.summary, event.title
+  end
 end

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ICalServiceTest < ActiveSupport::TestCase
   test 'returns icalendar object' do
-    service = ICalService.new(cal_start: 1.week.ago, cal_end: Time.current)
+    service = ICalService.new(event_start: 1.week.ago, event_end: Time.current)
 
     assert_kind_of Icalendar::Calendar, service.icalendar
   end

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ICalServiceTest < ActiveSupport::TestCase
+  test 'returns icalendar object' do
+    service = ICalService.new(cal_start: 1.week.ago, cal_end: Time.current)
+
+    assert_kind_of Icalendar::Calendar, service.icalendar
+  end
+end

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -8,12 +8,13 @@ class ICalServiceTest < ActiveSupport::TestCase
   end
 
   test 'returns events in window' do
-    Event.create(start: 1.hour.ago, end: Time.current)
-    Event.create(start: 2.weeks.ago, end: 1.week.ago)
+    Event.create!(start: 1.hour.ago, end: Time.current)
+    Event.create!(start: 2.weeks.ago, end: 1.week.ago)
+    Event.create!(start: 2.weeks.ago, end: 1.week.from_now)
 
     service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
 
-    assert_equal service.icalendar.events.count, 1
+    assert_equal 2, service.icalendar.events.count
   end
 
   test 'returns event parameters' do

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -22,8 +22,8 @@ class ICalServiceTest < ActiveSupport::TestCase
 
     service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
 
-    assert_equal event.start.to_date, service.icalendar.events.first.dtstart
-    assert_equal event.end.to_date, service.icalendar.events.first.dtend
-    assert_equal event.title, service.icalendar.events.first.summary
+    assert_equal service.icalendar.events.first.dtstart, event.start.to_date
+    assert_equal service.icalendar.events.first.dtend, event.end.to_date
+    assert_equal service.icalendar.events.first.summary, event.title
   end
 end

--- a/test/services/i_cal_service_test.rb
+++ b/test/services/i_cal_service_test.rb
@@ -18,7 +18,7 @@ class ICalServiceTest < ActiveSupport::TestCase
   end
 
   test 'returns event parameters' do
-    event = Event.create(start: 1.hour.ago, end: Time.current, title: 'Test title')
+    event = Event.create!(start: 1.hour.ago, end: Time.current, title: 'Test title')
 
     service = ICalService.new(event_start: 1.day.ago, event_end: Time.current)
 


### PR DESCRIPTION
This pull request introduces a new API endpoint for exporting events as an iCalendar (.ics) file within a specified date range. It adds the necessary service, controller, routing, documentation, and tests to support this feature.

**iCalendar Export Feature:**

* Added the `icalendar` gem to handle .ics file generation.
* Implemented the `ICalService` in `app/services/i_cal_service.rb` to generate an iCalendar file from events within a given date range.
* Created the `Api::V1::IcalendarController` with an `index` action to serve the .ics file based on `start` and `end` query parameters, returning a 400 error if parameters are missing.
* Updated routes to expose the new `/api/v1/icalendar` endpoint.
* Documented the new endpoint in the OpenAPI/Swagger spec, including parameter requirements and response formats.

**Testing:**

* Added controller tests for the new endpoint, including success and error cases.
* Added service tests to verify correct event selection and iCalendar formatting.